### PR TITLE
fortio2 destinationrule kustomization

### DIFF
--- a/test/asm/fortio2/fortio-ns-patch.yaml
+++ b/test/asm/fortio2/fortio-ns-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: fortio
+spec:
+  host:  fortio.fortio2.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: fortiosds
+spec:
+  host:  fortiosds.fortio2.svc.cluster.local

--- a/test/asm/fortio2/kustomization.yaml
+++ b/test/asm/fortio2/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ns.yaml
   - fortio.yaml
   - fortiosds.yaml
-
+patchesStrategicMerge:
+  - fortio-ns-patch.yaml
 namespace: fortio2


### PR DESCRIPTION
Adds another patch to the kustomization for test/asm/fortio2 to fix the namespace of the destinationrules